### PR TITLE
When addAppearListener is added, hover view cannot be dismissed. FIXED

### DIFF
--- a/library/src/main/java/com/daimajia/androidviewhover/BlurLayout.java
+++ b/library/src/main/java/com/daimajia/androidviewhover/BlurLayout.java
@@ -366,8 +366,8 @@ public class BlurLayout extends RelativeLayout {
         @Override
         public void onAnimationEnd(Animator animation) {
             mAppearingAnimators.remove(animation);
-            if(mAppearListeners.isEmpty()){
-                mHoverStatus = HOVER_STATUS.APPEARED;
+            mHoverStatus = HOVER_STATUS.APPEARED;
+            if(!mAppearListeners.isEmpty()){
                 for(AppearListener l : mAppearListeners){
                     l.onEnd();
                 }


### PR DESCRIPTION
If statement has one typo - lack of negation '!'. Negation added and mHoverStatus set a bit earlier.
