### PR TITLE
Shrink bitmap before blur,then zoom bitmap after blured

### DIFF
--- a/library/src/main/java/com/daimajia/androidviewhover/tools/Blur.java
+++ b/library/src/main/java/com/daimajia/androidviewhover/tools/Blur.java
@@ -18,9 +18,9 @@ public class Blur {
         return apply(context, sentBitmap, DEFAULT_BLUR_RADIUS, DEFAULT_SCALE);
     }
 
-    public static Bitmap apply(Context context, Bitmap sentBitmap, int radius, float scaleRadius) {
+    public static Bitmap apply(Context context, Bitmap sentBitmap, int radius) {
         // shrink half
-        sentBitmap = scaleBitmap(sentBitmap, 1 / scaleRadius);
+        sentBitmap = scaleBitmap(sentBitmap, 1 / DEFAULT_SCALE);
         final Bitmap bitmap = sentBitmap.copy(sentBitmap.getConfig(), true);
         final RenderScript rs = RenderScript.create(context);
         final Allocation input = Allocation.createFromBitmap(rs, sentBitmap, Allocation.MipmapControl.MIPMAP_NONE, Allocation.USAGE_SCRIPT);
@@ -32,7 +32,7 @@ public class Blur {
         script.forEach(output);
         output.copyTo(bitmap);
         //zoom bitmap
-        final Bitmap zoomBitmap = scaleBitmap(bitmap, scaleRadius);
+        final Bitmap zoomBitmap = scaleBitmap(bitmap, DEFAULT_SCALE);
         bitmap.recycle();
         sentBitmap.recycle();
         rs.destroy();

--- a/library/src/main/java/com/daimajia/androidviewhover/tools/Blur.java
+++ b/library/src/main/java/com/daimajia/androidviewhover/tools/Blur.java
@@ -15,7 +15,7 @@ public class Blur {
     private static final float DEFAULT_SCALE = 2;
 
     public static Bitmap apply(Context context, Bitmap sentBitmap) {
-        return apply(context, sentBitmap, DEFAULT_BLUR_RADIUS, DEFAULT_SCALE);
+        return apply(context, sentBitmap, DEFAULT_BLUR_RADIUS);
     }
 
     public static Bitmap apply(Context context, Bitmap sentBitmap, int radius) {

--- a/library/src/main/java/com/daimajia/androidviewhover/tools/Blur.java
+++ b/library/src/main/java/com/daimajia/androidviewhover/tools/Blur.java
@@ -1,6 +1,8 @@
 package com.daimajia.androidviewhover.tools;
+
 import android.graphics.Bitmap;
 import android.content.Context;
+import android.graphics.Matrix;
 import android.support.v8.renderscript.Allocation;
 import android.support.v8.renderscript.Element;
 import android.support.v8.renderscript.RenderScript;
@@ -10,12 +12,15 @@ import android.support.v8.renderscript.ScriptIntrinsicBlur;
 public class Blur {
 
     private static final int DEFAULT_BLUR_RADIUS = 10;
+    private static final float DEFAULT_SCALE = 2;
 
     public static Bitmap apply(Context context, Bitmap sentBitmap) {
-        return apply(context, sentBitmap, DEFAULT_BLUR_RADIUS);
+        return apply(context, sentBitmap, DEFAULT_BLUR_RADIUS, DEFAULT_SCALE);
     }
 
-    public static Bitmap apply(Context context, Bitmap sentBitmap, int radius) {
+    public static Bitmap apply(Context context, Bitmap sentBitmap, int radius, float scaleRadius) {
+        // shrink half
+        sentBitmap = scaleBitmap(sentBitmap, 1 / scaleRadius);
         final Bitmap bitmap = sentBitmap.copy(sentBitmap.getConfig(), true);
         final RenderScript rs = RenderScript.create(context);
         final Allocation input = Allocation.createFromBitmap(rs, sentBitmap, Allocation.MipmapControl.MIPMAP_NONE, Allocation.USAGE_SCRIPT);
@@ -26,13 +31,21 @@ public class Blur {
         script.setInput(input);
         script.forEach(output);
         output.copyTo(bitmap);
-
+        //zoom bitmap
+        final Bitmap zoomBitmap = scaleBitmap(bitmap, scaleRadius);
+        bitmap.recycle();
         sentBitmap.recycle();
         rs.destroy();
         input.destroy();
         output.destroy();
         script.destroy();
 
-        return bitmap;
+        return zoomBitmap;
+    }
+
+    public static Bitmap scaleBitmap(Bitmap oldBitmap, float scale) {
+        Matrix matrix = new Matrix();
+        matrix.postScale(scale, scale);
+        return Bitmap.createBitmap(oldBitmap, 0, 0, oldBitmap.getWidth(), oldBitmap.getHeight(), matrix, true);
     }
 }


### PR DESCRIPTION
在对图片进行高斯模糊处理的Blur.java文件中，进行模糊之前先将要模糊的图片尺寸缩小，再对缩小的图片进行模糊处理，最后将图片放大，这样相比之前对图片处理的时间会缩小一半，而且模糊效果也会更加明显，理论上说ScriptIntrinsicBlur进行模糊的范围只能从0~25，而使用图片的尺寸缩放后进行模糊处理能突破这个范围的限制。